### PR TITLE
Grammar fixes

### DIFF
--- a/Syntaxes/MiniYAML.tmLanguage
+++ b/Syntaxes/MiniYAML.tmLanguage
@@ -198,7 +198,7 @@
 		<key>comment</key>
 		<dict>
 			<key>begin</key>
-			<string>(?:(^[ \t]*)|[ \t]+)(?=#\p{Print}*$)</string>
+			<string>(?:(^[ \t]*)|[ \t]+)(?=#(\p{Print}|\t)*$)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>

--- a/Syntaxes/MiniYAML.tmLanguage
+++ b/Syntaxes/MiniYAML.tmLanguage
@@ -16,10 +16,6 @@
 		</dict>
 		<dict>
 			<key>include</key>
-			<string>#property</string>
-		</dict>
-		<dict>
-			<key>include</key>
 			<string>#directive</string>
 		</dict>
 		<dict>
@@ -884,59 +880,6 @@
 				</dict>
 			</array>
 		</dict>
-		<key>property</key>
-		<dict>
-			<key>begin</key>
-			<string>(?=!|&amp;)</string>
-			<key>end</key>
-			<string>(?!\G)</string>
-			<key>name</key>
-			<string>meta.property.miniyaml</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.control.property.anchor.miniyaml</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.anchor.miniyaml</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>entity.name.type.anchor.miniyaml</string>
-						</dict>
-						<key>4</key>
-						<dict>
-							<key>name</key>
-							<string>invalid.illegal.character.anchor.miniyaml</string>
-						</dict>
-					</dict>
-					<key>match</key>
-					<string>\G((&amp;))([^\s\[\]/{/},]+)(\S+)?</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>(?x)
-                        \G
-                        (?:
-                            ! &lt; (?: %[0-9A-Fa-f]{2} | [0-9A-Za-z\-#;/?:@&amp;=+$,_.!~*'()\[\]] )+ &gt;
-                          | (?:!(?:[0-9A-Za-z\-]*!)?) (?: %[0-9A-Fa-f]{2} | [0-9A-Za-z\-#;/?:@&amp;=+$_.~*'()] )+
-                          | !
-                        )
-                        (?=\ |\t|$)
-                    </string>
-					<key>name</key>
-					<string>storage.type.tag-handle.miniyaml</string>
-				</dict>
-			</array>
-		</dict>
 		<key>prototype</key>
 		<dict>
 			<key>patterns</key>
@@ -944,10 +887,6 @@
 				<dict>
 					<key>include</key>
 					<string>#comment</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#property</string>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION
This fixes three bugs:
 - Comments are not matched/highlighted in some cases
 - Some special characters at start of node values were breaking highlighting. While still not perfect, this is improved and will be fully fixed in a follow-up PR. (Main goal here is to fix ORA condition highlighting)
 
 <details>
    <summary>Click here for a visual comparison!</summary>

Here is a visual comparison of the BEFORE and AFTER applied to [my highlighting test file](https://github.com/penev92/OpenRA/blob/highlightingTest/mods/ts/A_highlighting_test.yaml):
![image](https://user-images.githubusercontent.com/7137365/160018687-3d39207c-0ac9-4433-a547-1b1c3f8cfbed.png)

</details>

P.S.:  Here are some useful resources that helped with my work:
 - [Rubular](https://rubular.com/) - a website to test the Ruby flavor of regular expressions because that's what the TM files are ran through apparently.
  - https://www.apeth.com/nonblog/stories/textmatebundle.html - useful info about creating a rules file. This is what pointed me at Rubular.
 - [Naming conventions docs](https://macromates.com/manual/en/language_grammars)
 - [RegExr](https://regexr.com) and [regex101](https://regex101.com/) - for general RegEx testing and explanations.
 - [YAML specs](https://yaml.org/spec/1.2.2/#73-flow-scalar-styles), [YAML specs](https://yaml.org/spec/1.2.2/#3234-directives), [YAML tutorials](https://www.tutorialspoint.com/yaml/yaml_sequence_styles.htm), [YAML tutorials](https://www.tutorialspoint.com/yaml/yaml_flow_styles.htm), [YAML tutorials](https://www.tutorialspoint.com/yaml/yaml_flow_mappings.htm) - for understanding what the rules inherited from YAML are for.
 - [My highlighting test file](https://github.com/penev92/OpenRA/blob/experiments/yamlHighlightingTest/mods/ts/A_highlighting_test.yaml)