### PR TITLE
Rules cleanup

### DIFF
--- a/Syntaxes/MiniYAML.tmLanguage
+++ b/Syntaxes/MiniYAML.tmLanguage
@@ -16,10 +16,6 @@
 		</dict>
 		<dict>
 			<key>include</key>
-			<string>#directive</string>
-		</dict>
-		<dict>
-			<key>include</key>
 			<string>#node</string>
 		</dict>
 	</array>
@@ -222,87 +218,6 @@
 					<string>\n</string>
 					<key>name</key>
 					<string>comment.line.number-sign.miniyaml</string>
-				</dict>
-			</array>
-		</dict>
-		<key>directive</key>
-		<dict>
-			<key>begin</key>
-			<string>^%</string>
-			<key>beginCaptures</key>
-			<dict>
-				<key>0</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.directive.begin.miniyaml</string>
-				</dict>
-			</dict>
-			<key>end</key>
-			<string>(?=$|[ \t]+($|#))</string>
-			<key>name</key>
-			<string>meta.directive.miniyaml</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.other.directive.tag.miniyaml</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>storage.type.tag-handle.miniyaml</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>support.type.tag-prefix.miniyaml</string>
-						</dict>
-					</dict>
-					<key>match</key>
-					<string>(?x)
-                        \G
-                        (TAG)
-                        (?:[ \t]+
-                            ((?:!(?:[0-9A-Za-z\-]*!)?))
-                            (?:[ \t]+ (
-                                  !              (?x: %[0-9A-Fa-f]{2} | [0-9A-Za-z\-#;/?:@&amp;=+$,_.!~*'()\[\]] )*
-                                | (?![,!\[\]{}]) (?x: %[0-9A-Fa-f]{2} | [0-9A-Za-z\-#;/?:@&amp;=+$,_.!~*'()\[\]] )+
-                                )
-                            )?
-                        )?
-                    </string>
-				</dict>
-				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>support.other.directive.reserved.miniyaml</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>string.unquoted.directive-name.miniyaml</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>string.unquoted.directive-parameter.miniyaml</string>
-						</dict>
-					</dict>
-					<key>match</key>
-					<string>(?x) \G (\w+) (?:[ \t]+ (\w+) (?:[ \t]+ (\w+))? )?</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>\S+</string>
-					<key>name</key>
-					<string>invalid.illegal.unrecognized.miniyaml</string>
 				</dict>
 			</array>
 		</dict>

--- a/Syntaxes/MiniYAML.tmLanguage
+++ b/Syntaxes/MiniYAML.tmLanguage
@@ -47,10 +47,6 @@
 			<array>
 				<dict>
 					<key>include</key>
-					<string>#block-scalar</string>
-				</dict>
-				<dict>
-					<key>include</key>
 					<string>#block-collection</string>
 				</dict>
 				<dict>
@@ -222,55 +218,7 @@
 			<array>
 				<dict>
 					<key>include</key>
-					<string>#flow-scalar-double-quoted</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#flow-scalar-single-quoted</string>
-				</dict>
-				<dict>
-					<key>include</key>
 					<string>#flow-scalar-plain-in</string>
-				</dict>
-			</array>
-		</dict>
-		<key>flow-scalar-double-quoted</key>
-		<dict>
-			<key>begin</key>
-			<string>"</string>
-			<key>beginCaptures</key>
-			<dict>
-				<key>0</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.string.begin.miniyaml</string>
-				</dict>
-			</dict>
-			<key>end</key>
-			<string>"</string>
-			<key>endCaptures</key>
-			<dict>
-				<key>0</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.string.end.miniyaml</string>
-				</dict>
-			</dict>
-			<key>name</key>
-			<string>string.quoted.double.miniyaml</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>match</key>
-					<string>\\([0abtnvfre "/\\N_Lp]|x\d\d|u\d{4}|U\d{8})</string>
-					<key>name</key>
-					<string>constant.character.escape.miniyaml</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>\\\n</string>
-					<key>name</key>
-					<string>constant.character.escape.double-quoted.newline.miniyaml</string>
 				</dict>
 			</array>
 		</dict>
@@ -418,40 +366,6 @@
                             )
                         )
                     </string>
-				</dict>
-			</array>
-		</dict>
-		<key>flow-scalar-single-quoted</key>
-		<dict>
-			<key>begin</key>
-			<string>'</string>
-			<key>beginCaptures</key>
-			<dict>
-				<key>0</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.string.begin.miniyaml</string>
-				</dict>
-			</dict>
-			<key>end</key>
-			<string>'(?!')</string>
-			<key>endCaptures</key>
-			<dict>
-				<key>0</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.string.end.miniyaml</string>
-				</dict>
-			</dict>
-			<key>name</key>
-			<string>string.quoted.single.miniyaml</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>match</key>
-					<string>''</string>
-					<key>name</key>
-					<string>constant.character.escape.single-quoted.miniyaml</string>
 				</dict>
 			</array>
 		</dict>

--- a/Syntaxes/MiniYAML.tmLanguage
+++ b/Syntaxes/MiniYAML.tmLanguage
@@ -27,10 +27,6 @@
 			<array>
 				<dict>
 					<key>include</key>
-					<string>#block-sequence</string>
-				</dict>
-				<dict>
-					<key>include</key>
 					<string>#block-mapping</string>
 				</dict>
 			</array>
@@ -179,13 +175,6 @@
 					<string>punctuation.separator.key-value.mapping.miniyaml</string>
 				</dict>
 			</array>
-		</dict>
-		<key>block-sequence</key>
-		<dict>
-			<key>match</key>
-			<string>(-)(?!\S)</string>
-			<key>name</key>
-			<string>punctuation.definition.block.sequence.item.miniyaml</string>
 		</dict>
 		<key>comment</key>
 		<dict>

--- a/Syntaxes/MiniYAML.tmLanguage
+++ b/Syntaxes/MiniYAML.tmLanguage
@@ -216,10 +216,6 @@
 			<array>
 				<dict>
 					<key>include</key>
-					<string>#flow-sequence</string>
-				</dict>
-				<dict>
-					<key>include</key>
 					<string>#flow-mapping</string>
 				</dict>
 			</array>
@@ -260,10 +256,6 @@
 					<key>name</key>
 					<string>punctuation.separator.mapping.miniyaml</string>
 				</dict>
-				<dict>
-					<key>include</key>
-					<string>#flow-pair</string>
-				</dict>
 			</array>
 		</dict>
 		<key>flow-node</key>
@@ -281,144 +273,6 @@
 				<dict>
 					<key>include</key>
 					<string>#flow-scalar</string>
-				</dict>
-			</array>
-		</dict>
-		<key>flow-pair</key>
-		<dict>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>begin</key>
-					<string>\?</string>
-					<key>beginCaptures</key>
-					<dict>
-						<key>0</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.key-value.begin.miniyaml</string>
-						</dict>
-					</dict>
-					<key>end</key>
-					<string>(?=[},\]])</string>
-					<key>name</key>
-					<string>meta.flow-pair.explicit.miniyaml</string>
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>include</key>
-							<string>#prototype</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#flow-pair</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#flow-node</string>
-						</dict>
-						<dict>
-							<key>begin</key>
-							<string>:(?=\s|$|[\[\]{},])</string>
-							<key>beginCaptures</key>
-							<dict>
-								<key>0</key>
-								<dict>
-									<key>name</key>
-									<string>punctuation.separator.key-value.mapping.miniyaml</string>
-								</dict>
-							</dict>
-							<key>end</key>
-							<string>(?=[},\]])</string>
-						</dict>
-					</array>
-				</dict>
-				<dict>
-					<key>begin</key>
-					<string>(?x)
-                        (?=
-                            (?:
-                                [^\s[-?:,\[\]{}#&amp;*!|&gt;'"%@`]]
-                              | [?:-] [^\s[\[\]{},]]
-                            )
-                            (
-                                  [^\s:[\[\]{},]]
-                                | : [^\s[\[\]{},]]
-                                | \s+ (?![#\s])
-                            )*
-                            \s*
-                            :
-							(\s|$)
-                        )
-                    </string>
-					<key>end</key>
-					<string>(?x)
-                        (?=
-                              \s* $
-                            | \s+ \#
-                            | \s* : (\s|$)
-                            | \s* : [\[\]{},]
-                            | \s* [\[\]{},]
-                        )
-                    </string>
-					<key>name</key>
-					<string>meta.flow-pair.key.miniyaml</string>
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>include</key>
-							<string>#flow-scalar-plain-in-implicit-type</string>
-						</dict>
-						<dict>
-							<key>begin</key>
-							<string>(?x)
-                                  [^\s[-?:,\[\]{}#&amp;*!|&gt;'"%@`]]
-                                | [?:-] [^\s[\[\]{},]]
-                            </string>
-							<key>beginCaptures</key>
-							<dict>
-								<key>0</key>
-								<dict>
-									<key>name</key>
-									<string>entity.name.tag.miniyaml</string>
-								</dict>
-							</dict>
-							<key>contentName</key>
-							<string>entity.name.tag.miniyaml</string>
-							<key>end</key>
-							<string>(?x)
-                                (?=
-                                      \s* $
-                                    | \s+ \#
-                                    | \s* : (\s|$)
-                                    | \s* : [\[\]{},]
-                                    | \s* [\[\]{},]
-                                )
-                            </string>
-							<key>name</key>
-							<string>string.unquoted.plain.in.miniyaml</string>
-						</dict>
-					</array>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#flow-node</string>
-				</dict>
-				<dict>
-					<key>begin</key>
-					<string>:(?=\s|$|[\[\]{},])</string>
-					<key>captures</key>
-					<dict>
-						<key>0</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.separator.key-value.mapping.miniyaml</string>
-						</dict>
-					</dict>
-					<key>end</key>
-					<string>(?=[},\]])</string>
-					<key>name</key>
-					<string>meta.flow-pair.miniyaml</string>
 				</dict>
 			</array>
 		</dict>
@@ -658,52 +512,6 @@
 					<string>''</string>
 					<key>name</key>
 					<string>constant.character.escape.single-quoted.miniyaml</string>
-				</dict>
-			</array>
-		</dict>
-		<key>flow-sequence</key>
-		<dict>
-			<key>begin</key>
-			<string>\[</string>
-			<key>beginCaptures</key>
-			<dict>
-				<key>0</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.sequence.begin.miniyaml</string>
-				</dict>
-			</dict>
-			<key>end</key>
-			<string>\]</string>
-			<key>endCaptures</key>
-			<dict>
-				<key>0</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.sequence.end.miniyaml</string>
-				</dict>
-			</dict>
-			<key>name</key>
-			<string>meta.flow-sequence.miniyaml</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>#prototype</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>,</string>
-					<key>name</key>
-					<string>punctuation.separator.sequence.miniyaml</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#flow-pair</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#flow-node</string>
 				</dict>
 			</array>
 		</dict>

--- a/Syntaxes/MiniYAML.tmLanguage
+++ b/Syntaxes/MiniYAML.tmLanguage
@@ -210,54 +210,6 @@
 				</dict>
 			</array>
 		</dict>
-		<key>flow-collection</key>
-		<dict>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>#flow-mapping</string>
-				</dict>
-			</array>
-		</dict>
-		<key>flow-mapping</key>
-		<dict>
-			<key>begin</key>
-			<string>\{</string>
-			<key>beginCaptures</key>
-			<dict>
-				<key>0</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.mapping.begin.miniyaml</string>
-				</dict>
-			</dict>
-			<key>end</key>
-			<string>\}</string>
-			<key>endCaptures</key>
-			<dict>
-				<key>0</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.mapping.end.miniyaml</string>
-				</dict>
-			</dict>
-			<key>name</key>
-			<string>meta.flow-mapping.miniyaml</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>#prototype</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>,</string>
-					<key>name</key>
-					<string>punctuation.separator.mapping.miniyaml</string>
-				</dict>
-			</array>
-		</dict>
 		<key>flow-node</key>
 		<dict>
 			<key>patterns</key>
@@ -265,10 +217,6 @@
 				<dict>
 					<key>include</key>
 					<string>#prototype</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#flow-collection</string>
 				</dict>
 				<dict>
 					<key>include</key>

--- a/Syntaxes/MiniYAML.tmLanguage
+++ b/Syntaxes/MiniYAML.tmLanguage
@@ -21,40 +21,6 @@
 	</array>
 	<key>repository</key>
 	<dict>
-		<key>block-collection</key>
-		<dict>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>#block-mapping</string>
-				</dict>
-			</array>
-		</dict>
-		<key>block-mapping</key>
-		<dict>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>#block-pair</string>
-				</dict>
-			</array>
-		</dict>
-		<key>block-node</key>
-		<dict>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>#block-collection</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#flow-scalar-plain-out</string>
-				</dict>
-			</array>
-		</dict>
 		<key>block-pair</key>
 		<dict>
 			<key>patterns</key>
@@ -240,7 +206,11 @@
 			<array>
 				<dict>
 					<key>include</key>
-					<string>#block-node</string>
+					<string>#block-pair</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#flow-scalar-plain-out</string>
 				</dict>
 			</array>
 		</dict>

--- a/Syntaxes/MiniYAML.tmLanguage
+++ b/Syntaxes/MiniYAML.tmLanguage
@@ -210,34 +210,6 @@
 				</dict>
 			</array>
 		</dict>
-		<key>flow-alias</key>
-		<dict>
-			<key>captures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>keyword.control.flow.alias.miniyaml</string>
-				</dict>
-				<key>2</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.alias.miniyaml</string>
-				</dict>
-				<key>3</key>
-				<dict>
-					<key>name</key>
-					<string>variable.other.alias.miniyaml</string>
-				</dict>
-				<key>4</key>
-				<dict>
-					<key>name</key>
-					<string>invalid.illegal.character.anchor.miniyaml</string>
-				</dict>
-			</dict>
-			<key>match</key>
-			<string>((\*))([^\s\[\]/{/},]+)([^\s\]},]\S*)?</string>
-		</dict>
 		<key>flow-collection</key>
 		<dict>
 			<key>patterns</key>
@@ -301,10 +273,6 @@
 				<dict>
 					<key>include</key>
 					<string>#prototype</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#flow-alias</string>
 				</dict>
 				<dict>
 					<key>include</key>

--- a/Syntaxes/MiniYAML.tmLanguage
+++ b/Syntaxes/MiniYAML.tmLanguage
@@ -53,52 +53,12 @@
 					<key>include</key>
 					<string>#flow-scalar-plain-out</string>
 				</dict>
-				<dict>
-					<key>include</key>
-					<string>#flow-node</string>
-				</dict>
 			</array>
 		</dict>
 		<key>block-pair</key>
 		<dict>
 			<key>patterns</key>
 			<array>
-				<dict>
-					<key>begin</key>
-					<string>\?</string>
-					<key>beginCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.key-value.begin.miniyaml</string>
-						</dict>
-					</dict>
-					<key>end</key>
-					<string>(?=\?)|^ *(:)|(:)</string>
-					<key>endCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.separator.key-value.mapping.miniyaml</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>invalid.illegal.expected-newline.miniyaml</string>
-						</dict>
-					</dict>
-					<key>name</key>
-					<string>meta.block-mapping.miniyaml</string>
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>include</key>
-							<string>#block-node</string>
-						</dict>
-					</array>
-				</dict>
 				<dict>
 					<key>begin</key>
 					<string>(?x)
@@ -127,10 +87,6 @@
                     </string>
 					<key>patterns</key>
 					<array>
-						<dict>
-							<key>include</key>
-							<string>#flow-scalar-plain-out-implicit-type</string>
-						</dict>
 						<dict>
 							<key>begin</key>
 							<string>(?x)
@@ -199,97 +155,6 @@
 					<string>\n</string>
 					<key>name</key>
 					<string>comment.line.number-sign.miniyaml</string>
-				</dict>
-			</array>
-		</dict>
-		<key>flow-node</key>
-		<dict>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>#flow-scalar</string>
-				</dict>
-			</array>
-		</dict>
-		<key>flow-scalar</key>
-		<dict>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>#flow-scalar-plain-in</string>
-				</dict>
-			</array>
-		</dict>
-		<key>flow-scalar-plain-in</key>
-		<dict>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>#flow-scalar-plain-in-implicit-type</string>
-				</dict>
-				<dict>
-					<key>begin</key>
-					<string>(?x)
-                          [^\s[-?:,\[\]{}#&amp;*!|&gt;'"%@`]]
-                        | [?:-] [^\s[\[\]{},]]
-                    </string>
-					<key>end</key>
-					<string>(?x)
-                        (?=
-                              \s* $
-                            | \s+ \#
-                            | \s* : (\s|$)
-                            | \s* : [\[\]{},]
-                            | \s* [\[\]{},]
-                        )
-                    </string>
-					<key>name</key>
-					<string>string.unquoted.plain.in.miniyaml</string>
-				</dict>
-			</array>
-		</dict>
-		<key>flow-scalar-plain-in-implicit-type</key>
-		<dict>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>constant.language.boolean.miniyaml</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>constant.numeric.integer.miniyaml</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>constant.numeric.float.miniyaml</string>
-						</dict>
-					</dict>
-					<key>match</key>
-					<string>(?x)
-                        (?x:
-                            (yes|Yes|YES|no|No|NO|true|True|TRUE|false|False|FALSE)
-                            | (
-                                (?:
-                                    [-+]? (?: 0|[1-9][0-9_]*) # (base 10)
-                                )
-                              )
-                            | (
-                                (?x:
-                                    [-+]? (?: [0-9] [0-9_]*)? \. [0-9.]* (?: [eE] [-+] [0-9]+)? # (base 10)
-                                )
-                              )
-                        )
-                    </string>
 				</dict>
 			</array>
 		</dict>

--- a/Syntaxes/MiniYAML.tmLanguage
+++ b/Syntaxes/MiniYAML.tmLanguage
@@ -330,13 +330,6 @@
 							</dict>
 							<key>end</key>
 							<string>(?=[},\]])</string>
-							<key>patterns</key>
-							<array>
-								<dict>
-									<key>include</key>
-									<string>#flow-value</string>
-								</dict>
-							</array>
 						</dict>
 					</array>
 				</dict>
@@ -426,13 +419,6 @@
 					<string>(?=[},\]])</string>
 					<key>name</key>
 					<string>meta.flow-pair.miniyaml</string>
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>include</key>
-							<string>#flow-value</string>
-						</dict>
-					</array>
 				</dict>
 			</array>
 		</dict>
@@ -718,27 +704,6 @@
 				<dict>
 					<key>include</key>
 					<string>#flow-node</string>
-				</dict>
-			</array>
-		</dict>
-		<key>flow-value</key>
-		<dict>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>begin</key>
-					<string>\G(?![},\]])</string>
-					<key>end</key>
-					<string>(?=[},\]])</string>
-					<key>name</key>
-					<string>meta.flow-pair.value.miniyaml</string>
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>include</key>
-							<string>#flow-node</string>
-						</dict>
-					</array>
 				</dict>
 			</array>
 		</dict>

--- a/Syntaxes/MiniYAML.tmLanguage
+++ b/Syntaxes/MiniYAML.tmLanguage
@@ -47,10 +47,6 @@
 			<array>
 				<dict>
 					<key>include</key>
-					<string>#prototype</string>
-				</dict>
-				<dict>
-					<key>include</key>
 					<string>#block-scalar</string>
 				</dict>
 				<dict>
@@ -214,10 +210,6 @@
 		<dict>
 			<key>patterns</key>
 			<array>
-				<dict>
-					<key>include</key>
-					<string>#prototype</string>
-				</dict>
 				<dict>
 					<key>include</key>
 					<string>#flow-scalar</string>
@@ -470,16 +462,6 @@
 				<dict>
 					<key>include</key>
 					<string>#block-node</string>
-				</dict>
-			</array>
-		</dict>
-		<key>prototype</key>
-		<dict>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>#comment</string>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION
There was a lot of rules that handle YAML special cases that don't apply to MiniYAML. I feel this simplifies the whole thing ***a lot***, which would make it easier for people to get into if changes need to be made.

VSCode shows no difference in highlighting (that I could find) before and after this PR, which is the intended result - clean up unused rules without changing the result.

Depends on #1 

P.S.:  Here are some useful resources that helped with my work:
 - [Rubular](https://rubular.com/) - a website to test the Ruby flavor of regular expressions because that's what the TM files are ran through apparently.
  - https://www.apeth.com/nonblog/stories/textmatebundle.html - useful info about creating a rules file. This is what pointed me at Rubular.
 - [Naming conventions docs](https://macromates.com/manual/en/language_grammars)
 - [RegExr](https://regexr.com) and [regex101](https://regex101.com/) - for general RegEx testing and explanations.
 - [YAML specs](https://yaml.org/spec/1.2.2/#73-flow-scalar-styles), [YAML specs](https://yaml.org/spec/1.2.2/#3234-directives), [YAML tutorials](https://www.tutorialspoint.com/yaml/yaml_sequence_styles.htm), [YAML tutorials](https://www.tutorialspoint.com/yaml/yaml_flow_styles.htm), [YAML tutorials](https://www.tutorialspoint.com/yaml/yaml_flow_mappings.htm) - for understanding what the rules inherited from YAML are for.
 - [My highlighting test file](https://github.com/penev92/OpenRA/blob/highlightingTest/mods/ts/A_highlighting_test.yaml)