### PR TITLE
Fixed node identifier expression highlighting ':'

### DIFF
--- a/Syntaxes/MiniYAML.tmLanguage
+++ b/Syntaxes/MiniYAML.tmLanguage
@@ -31,7 +31,7 @@
 		<key>node-identifier</key>
 		<dict>
 			<key>match</key>
-			<string>(?<=\S)(@\S+)(?::\s)</string>
+			<string>(?<=\S)(@\S+)(?=:\s)</string>
 			<key>name</key>
 			<string>entity.name.type.miniyaml</string>
 		</dict>


### PR DESCRIPTION
The node and node removal expressions don't include/capture/highlight the ':', so it makes no sense for the identifier one to do so.
(Switching non-capturing group, which still includes the result with a lookahead, which doesn't include it)